### PR TITLE
correct attribute stats

### DIFF
--- a/statsforecast.php
+++ b/statsforecast.php
@@ -729,7 +729,7 @@ class statsforecast extends Module
 					' . Shop::addSqlRestriction(Shop::SHARE_ORDER, 'o');
         $ca['ventil'] = Db::getInstance()->getRow($sql);
 
-        $sql = 'SELECT /*pac.id_attribute,*/ agl.name as gname, al.name as aname, COUNT(*) as total
+        $sql = 'SELECT /*pac.id_attribute,*/ agl.name as gname, al.name as aname, SUM(od.product_quantity) as total
 				FROM ' . _DB_PREFIX_ . 'orders o
 				LEFT JOIN ' . _DB_PREFIX_ . 'order_detail od ON o.id_order = od.id_order
 				INNER JOIN ' . _DB_PREFIX_ . 'product_attribute_combination pac ON od.product_attribute_id = pac.id_product_attribute


### PR DESCRIPTION
The attributes will now consider the quantities sold in each order

<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | The attributes stats do not consider the quantity sold in an order. 
| Type?         | bug fix
| BC breaks?    | no
| Deprecations? |  no
| Fixed ticket? | unknown
| How to test?  | Choose a time period with orders which contain items where the sold quantity > 1 . The attribute statistics will count only 1 for each order but should count every item sold. 

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
